### PR TITLE
Update GAAPICommon

### DIFF
--- a/src/FleetClients.Core/FleetClients.Core.csproj
+++ b/src/FleetClients.Core/FleetClients.Core.csproj
@@ -31,44 +31,44 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/FleetClients.Core/app.config
+++ b/src/FleetClients.Core/app.config
@@ -10,21 +10,14 @@
                 </binding>
             </netTcpBinding>
             <wsDualHttpBinding>
-                <binding name="WSDualHttpBinding_IFleetManagerService_PublicAPI_v2_0"
-                    messageEncoding="Mtom">
+                <binding name="WSDualHttpBinding_IFleetManagerService_PublicAPI_v2_0" messageEncoding="Mtom">
                     <security mode="None" />
                 </binding>
             </wsDualHttpBinding>
         </bindings>
         <client>
-            <endpoint address="http://127.0.0.1:41916/fleetManager.svc" binding="wsDualHttpBinding"
-                bindingConfiguration="WSDualHttpBinding_IFleetManagerService_PublicAPI_v2_0"
-                contract="FleetManagerServiceReference.IFleetManagerService_PublicAPI_v2_0"
-                name="WSDualHttpBinding_IFleetManagerService_PublicAPI_v2_0" />
-            <endpoint address="net.tcp://127.0.0.1:41917/fleetManager.svc"
-                binding="netTcpBinding" bindingConfiguration="NetTcpBinding_IFleetManagerService_PublicAPI_v2_0"
-                contract="FleetManagerServiceReference.IFleetManagerService_PublicAPI_v2_0"
-                name="NetTcpBinding_IFleetManagerService_PublicAPI_v2_0" />
+            <endpoint address="http://127.0.0.1:41916/fleetManager.svc" binding="wsDualHttpBinding" bindingConfiguration="WSDualHttpBinding_IFleetManagerService_PublicAPI_v2_0" contract="FleetManagerServiceReference.IFleetManagerService_PublicAPI_v2_0" name="WSDualHttpBinding_IFleetManagerService_PublicAPI_v2_0" />
+            <endpoint address="net.tcp://127.0.0.1:41917/fleetManager.svc" binding="netTcpBinding" bindingConfiguration="NetTcpBinding_IFleetManagerService_PublicAPI_v2_0" contract="FleetManagerServiceReference.IFleetManagerService_PublicAPI_v2_0" name="NetTcpBinding_IFleetManagerService_PublicAPI_v2_0" />
         </client>
     </system.serviceModel>
   <runtime>
@@ -32,6 +25,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/FleetClients.Core/packages.config
+++ b/src/FleetClients.Core/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net47" />
 </packages>

--- a/src/FleetClients.UI/FleetClients.UI.csproj
+++ b/src/FleetClients.UI/FleetClients.UI.csproj
@@ -32,41 +32,41 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/FleetClients.UI/app.config
+++ b/src/FleetClients.UI/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="MoreLinq" publicKeyToken="384d532d7e88985d" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/FleetClients.UI/packages.config
+++ b/src/FleetClients.UI/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/tests/FleetClients.Core.Test/FleetClients.Core.Test.csproj
+++ b/tests/FleetClients.Core.Test/FleetClients.Core.Test.csproj
@@ -36,44 +36,44 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.13.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.13.1\lib\net45\nunit.framework.dll</HintPath>

--- a/tests/FleetClients.Core.Test/app.config
+++ b/tests/FleetClients.Core.Test/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/tests/FleetClients.Core.Test/packages.config
+++ b/tests/FleetClients.Core.Test/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="NUnit" version="3.13.1" targetFramework="net472" />
   <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net47" />

--- a/tests/FleetClients.DemoApp/App.config
+++ b/tests/FleetClients.DemoApp/App.config
@@ -17,6 +17,10 @@
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/tests/FleetClients.DemoApp/FleetClients.DemoApp.csproj
+++ b/tests/FleetClients.DemoApp/FleetClients.DemoApp.csproj
@@ -35,44 +35,44 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Markdig, Version=0.23.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Markdig.0.23.0\lib\net452\Markdig.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/tests/FleetClients.DemoApp/packages.config
+++ b/tests/FleetClients.DemoApp/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
   <package id="Markdig" version="0.23.0" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />

--- a/tests/FleetClients.FleetClientConsole/App.config
+++ b/tests/FleetClients.FleetClientConsole/App.config
@@ -9,6 +9,10 @@
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/tests/FleetClients.FleetClientConsole/FleetClients.FleetClientConsole.csproj
+++ b/tests/FleetClients.FleetClientConsole/FleetClients.FleetClientConsole.csproj
@@ -33,44 +33,44 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="CommandLine, Version=2.9.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommandLineParser.2.9.0-preview1\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/tests/FleetClients.FleetClientConsole/packages.config
+++ b/tests/FleetClients.FleetClientConsole/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="CommandLineParser" version="2.9.0-preview1" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/tutorials/Tutorial 01/App.config
+++ b/tutorials/Tutorial 01/App.config
@@ -2,58 +2,62 @@
 <configuration>
   <configSections>
   <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-  <section name="entityFramework"
-    type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-    requirePermission="false"/>
+  <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <entityFramework>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
-      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6"/>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
     </providers>
   </entityFramework>
   <system.data>
     <DbProviderFactories>
-      <remove invariant="System.Data.SQLite.EF6"/>
-      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6"
-        description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6"/>
-    <remove invariant="System.Data.SQLite"/><add name="SQLite Data Provider" invariant="System.Data.SQLite"
-      description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite"/></DbProviderFactories>
+      <remove invariant="System.Data.SQLite.EF6" />
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
+    <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
   </system.data>
 	<system.diagnostics>
 		<sources>
 			<source name="System.ServiceModel" switchValue="Information, ActivityTracing" propagateActivity="true">
 				<listeners>
-					<add name="xml"/>
+					<add name="xml" />
 				</listeners>
 			</source>
 			<source name="CardSpace">
 				<listeners>
-					<add name="xml"/>
+					<add name="xml" />
 				</listeners>
 			</source>
 			<source name="System.IO.Log">
 				<listeners>
-					<add name="xml"/>
+					<add name="xml" />
 				</listeners>
 			</source>
 			<source name="System.Runtime.Serialization">
 				<listeners>
-					<add name="xml"/>
+					<add name="xml" />
 				</listeners>
 			</source>
 			<source name="System.IdentityModel">
 				<listeners>
-					<add name="xml"/>
+					<add name="xml" />
 				</listeners>
 			</source>
 		</sources>
 
 		<sharedListeners>
-			<add name="xml" type="System.Diagnostics.XmlWriterTraceListener" initializeData="c:\log\Traces.svclog"/>
+			<add name="xml" type="System.Diagnostics.XmlWriterTraceListener" initializeData="c:\log\Traces.svclog" />
 		</sharedListeners>
 	</system.diagnostics>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/tutorials/Tutorial 01/Tutorial 01.csproj
+++ b/tutorials/Tutorial 01/Tutorial 01.csproj
@@ -36,11 +36,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.dll</HintPath>
@@ -48,35 +48,35 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/tutorials/Tutorial 01/packages.config
+++ b/tutorials/Tutorial 01/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="EntityFramework" version="6.4.4" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.113.3" targetFramework="net472" />
   <package id="System.Data.SQLite" version="1.0.113.7" targetFramework="net472" />
   <package id="System.Data.SQLite.Core" version="1.0.113.7" targetFramework="net472" />

--- a/tutorials/Tutorial 02/App.config
+++ b/tutorials/Tutorial 02/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/tutorials/Tutorial 02/Tutorial 02.csproj
+++ b/tutorials/Tutorial 02/Tutorial 02.csproj
@@ -33,41 +33,41 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/tutorials/Tutorial 02/packages.config
+++ b/tutorials/Tutorial 02/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Update BaseClients to 2.2.0
Update to GAAPICommon 1.39.1
Update GACore to 2.6.0
Update Microsoft.Xaml.Behaviors.Wpf to 1.1.39 (to match Atlas II SS)
Update Newtonsoft.Json to 13.0.1 (to match Atlas II SS)
Update to NLog 4.7.9 (to match Atlas II SS)