### PR TITLE
AI-1158 Update to BaseClients 2.2.1

### DIFF
--- a/src/FleetClients.Core/Connected Services/FleetManagerServiceReference/FleetManagerService_PublicAPI.wsdl
+++ b/src/FleetClients.Core/Connected Services/FleetManagerServiceReference/FleetManagerService_PublicAPI.wsdl
@@ -45,6 +45,12 @@
   <wsdl:message name="IFleetManagerService_PublicAPI_v2_0_SubscriptionHeartbeat_OutputMessage">
     <wsdl:part name="parameters" element="tns:SubscriptionHeartbeatResponse" />
   </wsdl:message>
+  <wsdl:message name="IFleetManagerService_PublicAPI_v2_0_UnsubscribeHeartbeat_InputMessage">
+    <wsdl:part name="parameters" element="tns:UnsubscribeHeartbeat" />
+  </wsdl:message>
+  <wsdl:message name="IFleetManagerService_PublicAPI_v2_0_UnsubscribeHeartbeat_OutputMessage">
+    <wsdl:part name="parameters" element="tns:UnsubscribeHeartbeatResponse" />
+  </wsdl:message>
   <wsdl:message name="IFleetManagerService_PublicAPI_v2_0_GetKingpinDescription_InputMessage">
     <wsdl:part name="parameters" element="tns:GetKingpinDescription" />
   </wsdl:message>
@@ -102,6 +108,10 @@
       <wsdl:input wsaw:Action="http://tempuri.org/ISubscriptionService/SubscriptionHeartbeat" message="tns:IFleetManagerService_PublicAPI_v2_0_SubscriptionHeartbeat_InputMessage" />
       <wsdl:output wsaw:Action="http://tempuri.org/ISubscriptionService/SubscriptionHeartbeatResponse" message="tns:IFleetManagerService_PublicAPI_v2_0_SubscriptionHeartbeat_OutputMessage" />
     </wsdl:operation>
+    <wsdl:operation name="UnsubscribeHeartbeat">
+      <wsdl:input wsaw:Action="http://tempuri.org/ISubscriptionService/UnsubscribeHeartbeat" message="tns:IFleetManagerService_PublicAPI_v2_0_UnsubscribeHeartbeat_InputMessage" />
+      <wsdl:output wsaw:Action="http://tempuri.org/ISubscriptionService/UnsubscribeHeartbeatResponse" message="tns:IFleetManagerService_PublicAPI_v2_0_UnsubscribeHeartbeat_OutputMessage" />
+    </wsdl:operation>
     <wsdl:operation name="GetKingpinDescription">
       <wsdl:input wsaw:Action="http://tempuri.org/IFleetManagerService_BaseAPI/GetKingpinDescription" message="tns:IFleetManagerService_PublicAPI_v2_0_GetKingpinDescription_InputMessage" />
       <wsdl:output wsaw:Action="http://tempuri.org/IFleetManagerService_BaseAPI/GetKingpinDescriptionResponse" message="tns:IFleetManagerService_PublicAPI_v2_0_GetKingpinDescription_OutputMessage" />
@@ -149,6 +159,15 @@
     </wsdl:operation>
     <wsdl:operation name="SubscriptionHeartbeat">
       <soap12:operation soapAction="http://tempuri.org/ISubscriptionService/SubscriptionHeartbeat" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="UnsubscribeHeartbeat">
+      <soap12:operation soapAction="http://tempuri.org/ISubscriptionService/UnsubscribeHeartbeat" style="document" />
       <wsdl:input>
         <soap12:body use="literal" />
       </wsdl:input>
@@ -243,6 +262,15 @@
     </wsdl:operation>
     <wsdl:operation name="SubscriptionHeartbeat">
       <soap12:operation soapAction="http://tempuri.org/ISubscriptionService/SubscriptionHeartbeat" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="UnsubscribeHeartbeat">
+      <soap12:operation soapAction="http://tempuri.org/ISubscriptionService/UnsubscribeHeartbeat" style="document" />
       <wsdl:input>
         <soap12:body use="literal" />
       </wsdl:input>

--- a/src/FleetClients.Core/Connected Services/FleetManagerServiceReference/Reference.cs
+++ b/src/FleetClients.Core/Connected Services/FleetManagerServiceReference/Reference.cs
@@ -27,6 +27,12 @@ namespace FleetClients.Core.FleetManagerServiceReference {
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/ISubscriptionService/SubscriptionHeartbeat", ReplyAction="http://tempuri.org/ISubscriptionService/SubscriptionHeartbeatResponse")]
         System.Threading.Tasks.Task SubscriptionHeartbeatAsync(System.Guid guid);
         
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/ISubscriptionService/UnsubscribeHeartbeat", ReplyAction="http://tempuri.org/ISubscriptionService/UnsubscribeHeartbeatResponse")]
+        void UnsubscribeHeartbeat(System.Guid guid);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/ISubscriptionService/UnsubscribeHeartbeat", ReplyAction="http://tempuri.org/ISubscriptionService/UnsubscribeHeartbeatResponse")]
+        System.Threading.Tasks.Task UnsubscribeHeartbeatAsync(System.Guid guid);
+        
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IFleetManagerService_BaseAPI/GetKingpinDescription", ReplyAction="http://tempuri.org/IFleetManagerService_BaseAPI/GetKingpinDescriptionResponse")]
         GAAPICommon.Core.Dtos.ServiceCallResultDto<System.Xml.Linq.XElement> GetKingpinDescription(System.Net.IPAddress ipAddress);
         
@@ -131,6 +137,14 @@ namespace FleetClients.Core.FleetManagerServiceReference {
         
         public System.Threading.Tasks.Task SubscriptionHeartbeatAsync(System.Guid guid) {
             return base.Channel.SubscriptionHeartbeatAsync(guid);
+        }
+        
+        public void UnsubscribeHeartbeat(System.Guid guid) {
+            base.Channel.UnsubscribeHeartbeat(guid);
+        }
+        
+        public System.Threading.Tasks.Task UnsubscribeHeartbeatAsync(System.Guid guid) {
+            return base.Channel.UnsubscribeHeartbeatAsync(guid);
         }
         
         public GAAPICommon.Core.Dtos.ServiceCallResultDto<System.Xml.Linq.XElement> GetKingpinDescription(System.Net.IPAddress ipAddress) {

--- a/src/FleetClients.Core/Connected Services/FleetManagerServiceReference/fleetManager1.xsd
+++ b/src/FleetClients.Core/Connected Services/FleetManagerServiceReference/fleetManager1.xsd
@@ -28,111 +28,123 @@
       <xs:sequence />
     </xs:complexType>
   </xs:element>
+  <xs:element name="UnsubscribeHeartbeat">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element xmlns:q3="http://schemas.microsoft.com/2003/10/Serialization/" minOccurs="0" name="guid" type="q3:guid" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UnsubscribeHeartbeatResponse">
+    <xs:complexType>
+      <xs:sequence />
+    </xs:complexType>
+  </xs:element>
   <xs:element name="GetKingpinDescription">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q3="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q3:IPAddress" />
+        <xs:element xmlns:q4="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q4:IPAddress" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="GetKingpinDescriptionResponse">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q4="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="GetKingpinDescriptionResult" nillable="true" type="q4:ServiceCallResultDtoOfXElementg0J7U6Qr" />
+        <xs:element xmlns:q5="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="GetKingpinDescriptionResult" nillable="true" type="q5:ServiceCallResultDtoOfXElementg0J7U6Qr" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="SetFrozenState">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q5="http://schemas.datacontract.org/2004/07/GAAPICommon.Architecture" minOccurs="0" name="frozenState" type="q5:FrozenState" />
+        <xs:element xmlns:q6="http://schemas.datacontract.org/2004/07/GAAPICommon.Architecture" minOccurs="0" name="frozenState" type="q6:FrozenState" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="SetFrozenStateResponse">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q6="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="SetFrozenStateResult" nillable="true" type="q6:ServiceCallResultDto" />
+        <xs:element xmlns:q7="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="SetFrozenStateResult" nillable="true" type="q7:ServiceCallResultDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="CreateVirtualVehicle">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q7="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q7:IPAddress" />
-        <xs:element xmlns:q8="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="pose" nillable="true" type="q8:PoseDto" />
+        <xs:element xmlns:q8="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q8:IPAddress" />
+        <xs:element xmlns:q9="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="pose" nillable="true" type="q9:PoseDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="CreateVirtualVehicleResponse">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q9="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="CreateVirtualVehicleResult" nillable="true" type="q9:ServiceCallResultDto" />
+        <xs:element xmlns:q10="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="CreateVirtualVehicleResult" nillable="true" type="q10:ServiceCallResultDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="RemoveVehicle">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q10="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q10:IPAddress" />
+        <xs:element xmlns:q11="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q11:IPAddress" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="RemoveVehicleResponse">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q11="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="RemoveVehicleResult" nillable="true" type="q11:ServiceCallResultDto" />
+        <xs:element xmlns:q12="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="RemoveVehicleResult" nillable="true" type="q12:ServiceCallResultDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="SetPose">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q12="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q12:IPAddress" />
-        <xs:element xmlns:q13="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="pose" nillable="true" type="q13:PoseDto" />
+        <xs:element xmlns:q13="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q13:IPAddress" />
+        <xs:element xmlns:q14="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="pose" nillable="true" type="q14:PoseDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="SetPoseResponse">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q14="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="SetPoseResult" nillable="true" type="q14:ServiceCallResultDto" />
+        <xs:element xmlns:q15="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="SetPoseResult" nillable="true" type="q15:ServiceCallResultDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="SetFleetState">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q15="http://schemas.datacontract.org/2004/07/GAAPICommon.Architecture" minOccurs="0" name="controllerState" type="q15:VehicleControllerState" />
+        <xs:element xmlns:q16="http://schemas.datacontract.org/2004/07/GAAPICommon.Architecture" minOccurs="0" name="controllerState" type="q16:VehicleControllerState" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="SetFleetStateResponse">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q16="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="SetFleetStateResult" nillable="true" type="q16:ServiceCallResultDto" />
+        <xs:element xmlns:q17="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="SetFleetStateResult" nillable="true" type="q17:ServiceCallResultDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="SetKingpinState">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q17="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q17:IPAddress" />
-        <xs:element xmlns:q18="http://schemas.datacontract.org/2004/07/GAAPICommon.Architecture" minOccurs="0" name="controllerState" type="q18:VehicleControllerState" />
+        <xs:element xmlns:q18="http://schemas.datacontract.org/2004/07/System.Net" minOccurs="0" name="ipAddress" nillable="true" type="q18:IPAddress" />
+        <xs:element xmlns:q19="http://schemas.datacontract.org/2004/07/GAAPICommon.Architecture" minOccurs="0" name="controllerState" type="q19:VehicleControllerState" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="SetKingpinStateResponse">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q19="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="SetKingpinStateResult" nillable="true" type="q19:ServiceCallResultDto" />
+        <xs:element xmlns:q20="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="SetKingpinStateResult" nillable="true" type="q20:ServiceCallResultDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="OnCallback">
     <xs:complexType>
       <xs:sequence>
-        <xs:element xmlns:q20="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="callbackObject" nillable="true" type="q20:FleetStateDto" />
+        <xs:element xmlns:q21="http://schemas.datacontract.org/2004/07/GAAPICommon.Core.Dtos" minOccurs="0" name="callbackObject" nillable="true" type="q21:FleetStateDto" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/src/FleetClients.Core/FleetClients.Core.csproj
+++ b/src/FleetClients.Core/FleetClients.Core.csproj
@@ -31,11 +31,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>

--- a/src/FleetClients.Core/FleetManagerClient.cs
+++ b/src/FleetClients.Core/FleetManagerClient.cs
@@ -187,5 +187,10 @@ namespace FleetClients.Core
         {
             channel.SubscriptionHeartbeat(key);
         }
+
+        protected override void HandleUnsubscribeHeartbeat(IFleetManagerService_PublicAPI_v2_0 channel, Guid key)
+        {
+            channel.UnsubscribeHeartbeat(key);
+        }
     }
 }

--- a/src/FleetClients.Core/packages.config
+++ b/src/FleetClients.Core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.1" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
   <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="GACore" version="2.6.0" targetFramework="net472" />

--- a/src/FleetClients.UI/FleetClients.UI.csproj
+++ b/src/FleetClients.UI/FleetClients.UI.csproj
@@ -32,11 +32,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>

--- a/src/FleetClients.UI/packages.config
+++ b/src/FleetClients.UI/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.1" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
   <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="GACore" version="2.6.0" targetFramework="net472" />

--- a/tests/FleetClients.Core.Test/FleetClients.Core.Test.csproj
+++ b/tests/FleetClients.Core.Test/FleetClients.Core.Test.csproj
@@ -36,11 +36,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>

--- a/tests/FleetClients.Core.Test/packages.config
+++ b/tests/FleetClients.Core.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.1" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
   <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="GACore" version="2.6.0" targetFramework="net472" />

--- a/tests/FleetClients.DemoApp/FleetClients.DemoApp.csproj
+++ b/tests/FleetClients.DemoApp/FleetClients.DemoApp.csproj
@@ -35,11 +35,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>

--- a/tests/FleetClients.DemoApp/packages.config
+++ b/tests/FleetClients.DemoApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.1" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
   <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="GACore" version="2.6.0" targetFramework="net472" />

--- a/tests/FleetClients.FleetClientConsole/FleetClients.FleetClientConsole.csproj
+++ b/tests/FleetClients.FleetClientConsole/FleetClients.FleetClientConsole.csproj
@@ -33,11 +33,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="CommandLine, Version=2.9.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommandLineParser.2.9.0-preview1\lib\net461\CommandLine.dll</HintPath>

--- a/tests/FleetClients.FleetClientConsole/packages.config
+++ b/tests/FleetClients.FleetClientConsole/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.1" targetFramework="net472" />
   <package id="CommandLineParser" version="2.9.0-preview1" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
   <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />

--- a/tutorials/Tutorial 01/Tutorial 01.csproj
+++ b/tutorials/Tutorial 01/Tutorial 01.csproj
@@ -36,11 +36,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.dll</HintPath>

--- a/tutorials/Tutorial 01/packages.config
+++ b/tutorials/Tutorial 01/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.1" targetFramework="net472" />
   <package id="EntityFramework" version="6.4.4" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
   <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />

--- a/tutorials/Tutorial 02/Tutorial 02.csproj
+++ b/tutorials/Tutorial 02/Tutorial 02.csproj
@@ -33,11 +33,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.1\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>

--- a/tutorials/Tutorial 02/packages.config
+++ b/tutorials/Tutorial 02/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.1" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
   <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="GACore" version="2.6.0" targetFramework="net472" />


### PR DESCRIPTION
Updates FleetClients to use BaseClients 2.2.1 including updates to WCF interface to handle the new BaseClients HandleUnsubscribeHeartbeat() API.